### PR TITLE
Fixed superuser account security problems

### DIFF
--- a/Wordle+/django/djangoproject/settings.py
+++ b/Wordle+/django/djangoproject/settings.py
@@ -124,7 +124,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Europe/Madrid'
 
 USE_I18N = True
 

--- a/Wordle+/django/djapi/admin.py
+++ b/Wordle+/django/djapi/admin.py
@@ -35,6 +35,25 @@ class CustomUserAdmin(UserAdmin):
             return self.readonly_fields + ('username',)
         return self.readonly_fields  # Creation of a new user
 
+    # Overwritten method. It makes the staff members not to be able to delete the
+    # superuser account, but they can delete other staff accounts.
+    def has_delete_permission(self, request, obj=None):
+        if obj is not None and obj.is_superuser:
+            if request.user.is_superuser:
+                return True
+            return False
+
+        if not request.user.is_superuser and obj is not None and obj.is_staff:
+            return True
+        return super().has_delete_permission(request, obj)
+    
+    # Overwritten method. It makes the staff members not to be able to edit the
+    # superuser account, but they can edit other staff accounts.
+    def has_change_permission(self, request, obj=None):
+        if obj is not None and obj.is_superuser and not request.user.is_superuser:
+            return False
+        return super().has_change_permission(request, obj)
+
 class PlayerAdmin(admin.ModelAdmin):
     list_display = ('id', 'user', 'wins', 'wins_pvp', 'wins_tournament', 'xp',)
     list_filter = ('user',)

--- a/Wordle+/django/djapi/permissions.py
+++ b/Wordle+/django/djapi/permissions.py
@@ -32,7 +32,7 @@ class IsOwnerOrAdminPermission(permissions.BasePermission):
         if hasattr(obj, 'user') and obj.user == request.user:
             return True
         
-        if request.user.is_staff:
+        if request.user.is_staff and not obj.is_superuser:
             return True
         
         return False


### PR DESCRIPTION
The superuser account is now only editable and deletable by the superuser. Any of the staff members can manage the superuser account.

Besides, the timezone of the project has changed to "Europe/Madrid" to store the correct `datetimes` values.