### PR TITLE
Log out added

### DIFF
--- a/Wordle+/ionic/ionic-app/src/app/components/logout-button/logout-button.component.html
+++ b/Wordle+/ionic/ionic-app/src/app/components/logout-button/logout-button.component.html
@@ -1,0 +1,1 @@
+<ion-button class="logout-button" (click)="logout()">Log out</ion-button>

--- a/Wordle+/ionic/ionic-app/src/app/components/logout-button/logout-button.component.scss
+++ b/Wordle+/ionic/ionic-app/src/app/components/logout-button/logout-button.component.scss
@@ -1,0 +1,3 @@
+.logout-button {
+    --background: #f44336;
+  }

--- a/Wordle+/ionic/ionic-app/src/app/components/logout-button/logout-button.component.spec.ts
+++ b/Wordle+/ionic/ionic-app/src/app/components/logout-button/logout-button.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+
+import { LogoutButtonComponent } from './logout-button.component';
+
+describe('LogoutButtonComponent', () => {
+  let component: LogoutButtonComponent;
+  let fixture: ComponentFixture<LogoutButtonComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LogoutButtonComponent ],
+      imports: [IonicModule.forRoot()]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LogoutButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Wordle+/ionic/ionic-app/src/app/components/logout-button/logout-button.component.ts
+++ b/Wordle+/ionic/ionic-app/src/app/components/logout-button/logout-button.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { StorageService } from '../../services/storage.service';
+
+
+@Component({
+  selector: 'app-logout-button',
+  templateUrl: './logout-button.component.html',
+  styleUrls: ['./logout-button.component.scss'],
+})
+export class LogoutButtonComponent {
+
+  constructor(private storageService: StorageService, private router: Router) {}
+
+  logout() {
+    this.storageService.removeAccessToken();
+    this.router.navigateByUrl('/login');
+  }
+}

--- a/Wordle+/ionic/ionic-app/src/app/pages/login/login.page.ts
+++ b/Wordle+/ionic/ionic-app/src/app/pages/login/login.page.ts
@@ -58,6 +58,6 @@ export class LoginPage implements OnInit {
   }
 
   goToAdminPage() {
-    window.location.href = 'http://localhost/admin/';
+    window.location.href = 'http://localhost:8080/admin/';
   }
 }

--- a/Wordle+/ionic/ionic-app/src/app/tab1/tab1.module.ts
+++ b/Wordle+/ionic/ionic-app/src/app/tab1/tab1.module.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Tab1Page } from './tab1.page';
 import { ExploreContainerComponentModule } from '../explore-container/explore-container.module';
+import { LogoutButtonComponent } from '../components/logout-button/logout-button.component';
 
 import { Tab1PageRoutingModule } from './tab1-routing.module';
 
@@ -15,6 +16,6 @@ import { Tab1PageRoutingModule } from './tab1-routing.module';
     ExploreContainerComponentModule,
     Tab1PageRoutingModule
   ],
-  declarations: [Tab1Page]
+  declarations: [Tab1Page, LogoutButtonComponent]
 })
 export class Tab1PageModule {}

--- a/Wordle+/ionic/ionic-app/src/app/tab1/tab1.page.html
+++ b/Wordle+/ionic/ionic-app/src/app/tab1/tab1.page.html
@@ -11,7 +11,9 @@
     <ion-toolbar>
       <ion-title size="large">Tab 1</ion-title>
     </ion-toolbar>
+
+    
   </ion-header>
 
-  <app-explore-container name="Tab 1 page"></app-explore-container>
+  <app-logout-button></app-logout-button>
 </ion-content>


### PR DESCRIPTION
# Description

The aim of this PR is to add the log out component and its related logic.
The logout button has been implemented as a component. This allows to use the component in any page that imports the component.

The logic of the button consists in remove the `access_token` variable stored in the Ionic Storage.