### PR TITLE
Token expiration logic added

### DIFF
--- a/Wordle+/django/djangoproject/settings.py
+++ b/Wordle+/django/djangoproject/settings.py
@@ -55,11 +55,12 @@ REST_FRAMEWORK = {
 }
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'djapi.token_expire.TokenExpirationMiddleware',
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -145,6 +146,7 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = 'djapi.CustomUser'
+TOKEN_EXPIRED_AFTER_SECONDS = 3600
 
 ## Conection with the FrontEnd
 

--- a/Wordle+/django/djapi/token_expire.py
+++ b/Wordle+/django/djapi/token_expire.py
@@ -1,0 +1,28 @@
+from rest_framework.authtoken.models import Token
+from datetime import timedelta
+from rest_framework import status
+from django.utils import timezone
+from rest_framework.authtoken.models import Token
+from django.http import JsonResponse
+from django.conf import settings
+
+class TokenExpirationMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        auth_header = request.META.get('HTTP_AUTHORIZATION')
+        if auth_header:
+            _, token_key = auth_header.split()
+            token = Token.objects.filter(key=token_key).first()
+            if token and token.created < timezone.now() - timedelta(seconds=settings.TOKEN_EXPIRED_AFTER_SECONDS):
+                token.delete()
+
+                response_data = {
+                    'message': 'Token has expired.'
+                }
+                response = JsonResponse(response_data, status=status.HTTP_401_UNAUTHORIZED)
+                return response
+
+        response = self.get_response(request)
+        return response


### PR DESCRIPTION
The aim of this PR is to add the necessary logic to remove tokens when they have expired. This logic is not implemented by default by the `rest_framework.auth` tool.

Tokens with expiration times allow you to enforce access control policies more effectively. By setting shorter expiration times, you can enforce re-authentication at regular intervals, ensuring that users and clients have valid authorization to access protected resources.