### PR TITLE
API service added

### DIFF
--- a/Wordle+/django/djangoproject/settings.py
+++ b/Wordle+/django/djangoproject/settings.py
@@ -59,13 +59,13 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'djapi.token_expire.TokenExpirationMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'djapi.token_expire.TokenExpirationMiddleware'
 
 ]
 

--- a/Wordle+/django/djangoproject/urls.py
+++ b/Wordle+/django/djangoproject/urls.py
@@ -17,6 +17,7 @@ from django.urls import include, path
 from django.contrib import admin
 from rest_framework import routers
 from djapi import views
+from djapi.views import CustomObtainAuthToken
 from rest_framework.authtoken.views import ObtainAuthToken
 
 router = routers.DefaultRouter()
@@ -30,5 +31,5 @@ urlpatterns = [
     path('', include(router.urls)),
     path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     path('admin/', admin.site.urls),
-    path('api-token-auth/', ObtainAuthToken.as_view())
+    path('api-token-auth/', CustomObtainAuthToken.as_view())
 ]

--- a/Wordle+/ionic/ionic-app/src/app/pages/login/login.module.ts
+++ b/Wordle+/ionic/ionic-app/src/app/pages/login/login.module.ts
@@ -4,6 +4,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { IonicModule } from '@ionic/angular';
 import { IonicStorageModule } from '@ionic/storage-angular';
+import { ApiService } from 'src/app/services/api.service';
 
 import { LoginPageRoutingModule } from './login-routing.module';
 
@@ -19,6 +20,7 @@ import { LoginPage } from './login.page';
     HttpClientModule,
     IonicStorageModule.forRoot()
   ],
-  declarations: [LoginPage]
+  declarations: [LoginPage],
+  providers: [ApiService]
 })
 export class LoginPageModule {}

--- a/Wordle+/ionic/ionic-app/src/app/pages/login/login.page.ts
+++ b/Wordle+/ionic/ionic-app/src/app/pages/login/login.page.ts
@@ -4,7 +4,7 @@ import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { StorageService } from '../../services/storage.service';
 import { EncryptionService } from '../../services/encryption.service';
-
+import { ApiService } from '../../services/api.service';
 
 @Component({
   selector: 'app-login',
@@ -21,10 +21,10 @@ export class LoginPage implements OnInit {
 
   constructor(
     public formBuilder: FormBuilder, 
-    private http: HttpClient, 
     private router: Router,
     private storageService: StorageService,
-    private encryptionService: EncryptionService
+    private encryptionService: EncryptionService,
+    private apiService: ApiService
     ) {}
 
   ngOnInit() {
@@ -41,7 +41,7 @@ export class LoginPage implements OnInit {
       password: this.loginForm.get('password').value,
     }
 
-    this.http.post<any>('http://localhost:8080/api-token-auth/', credentials).subscribe(
+    this.apiService.login(credentials).subscribe(
       async (response) => {
         // Store the token in the local storage
         this.errorMessage = ''

--- a/Wordle+/ionic/ionic-app/src/app/pages/register/register.module.ts
+++ b/Wordle+/ionic/ionic-app/src/app/pages/register/register.module.ts
@@ -3,9 +3,9 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { IonicModule } from '@ionic/angular';
+import { ApiService } from 'src/app/services/api.service';
 
 import { RegisterPageRoutingModule } from './register-routing.module';
-
 import { RegisterPage } from './register.page';
 
 @NgModule({
@@ -17,6 +17,7 @@ import { RegisterPage } from './register.page';
     HttpClientModule,
     RegisterPageRoutingModule
   ],
-  declarations: [RegisterPage]
+  declarations: [RegisterPage],
+  providers: [ApiService]
 })
 export class RegisterPageModule {}

--- a/Wordle+/ionic/ionic-app/src/app/services/api.service.ts
+++ b/Wordle+/ionic/ionic-app/src/app/services/api.service.ts
@@ -1,0 +1,30 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+@Injectable({
+    providedIn: 'root'
+  })
+  export class ApiService {
+    
+    private readonly baseURL = 'http://localhost:8080'
+    constructor(private http: HttpClient) { }
+  
+    login(credentials: any): Observable<any> {
+        const url = `${this.baseURL}/api-token-auth/`;
+        return this.http.post(url, credentials);
+    }
+
+    createPlayer(userData: any): Observable<any> {
+        const url = `${this.baseURL}/api/players/`;
+        const body = { user: userData };
+        return this.http.post(url, body);
+    }
+    
+    createUser(userData: any): Observable<any> {
+        let url = `${this.baseURL}/api/users/`;
+        return this.http.post(url, userData);
+    }
+  
+  
+  }


### PR DESCRIPTION
The aim of this PR is to change the way the API is used in Ionic. Now, instead of calling the URLs directly, it uses a new service that defines the available paths of the backend.

Besides, a new fix is added to check expired tokens when using the `api-token-auth` method.