### PR TITLE
Added tournament creation

### DIFF
--- a/Wordle+/django/djangoproject/urls.py
+++ b/Wordle+/django/djangoproject/urls.py
@@ -17,7 +17,7 @@ from django.urls import include, path
 from django.contrib import admin
 from rest_framework import routers
 from djapi import views
-from djapi.views import CustomObtainAuthToken, CheckTokenExpirationView, AvatarView, UserInfoAPIView
+from djapi.views import CustomObtainAuthToken, CheckTokenExpirationView, AvatarView, UserInfoAPIView, TournamentViewSet
 from django.conf import settings
 from django.conf.urls.static import static
 
@@ -36,6 +36,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api-token-auth/', CustomObtainAuthToken.as_view()),
     path('check-token-expiration/', CheckTokenExpirationView.as_view(), name='check-token-expiration'),
+    
     path('api/avatar/<int:user_id>/', AvatarView.as_view(), name='avatar'),
     path('api/users-info/', UserInfoAPIView.as_view(), name='user-detail'),
+    path('api/tournaments/', TournamentViewSet.as_view({'get': 'list'}), name='tournaments-list'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/Wordle+/django/djapi/admin.py
+++ b/Wordle+/django/djapi/admin.py
@@ -1,9 +1,10 @@
+from django.forms import Select
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
-from django.contrib.auth.models import Permission, Group
-from django.contrib.contenttypes.models import ContentType
+from django.db import models
+from django import forms
 
-from .models import CustomUser, Player, StaffCode, ClassicWordle, Notifications
+from .models import CustomUser, Player, StaffCode, ClassicWordle, Notification, Tournament
 
 class CustomUserAdmin(UserAdmin):
     model = CustomUser
@@ -84,10 +85,36 @@ class StaffCodeAdmin(admin.ModelAdmin):
 class ClassicWordleAdmin(admin.ModelAdmin):
     list_display = ['id', 'player', 'word', 'date_played']
 
-class NotificationsAdmin(admin.ModelAdmin):
+class NotificationAdmin(admin.ModelAdmin):
     list_display = ('id', 'player', 'text', 'link', 'timestamp')
 
-admin.site.register(Notifications, NotificationsAdmin)
+class TournamentsForm(forms.ModelForm):
+    word_length = forms.ChoiceField(choices=[
+        (4, '4'),
+        (5, '5'),
+        (6, '6'),
+        (7, '7'),
+        (8, '8'),
+    ])
+
+    max_players = forms.ChoiceField(choices=[
+        (2, '2'),
+        (4, '4'),
+        (8, '8'),
+        (16, '16'),
+    ])
+
+    class Meta:
+        model = Tournament
+        fields = '__all__'
+
+class TournamentAdmin(admin.ModelAdmin):
+    list_display = ('name', 'description', 'max_players', 'word_length', 'is_closed')
+    form = TournamentsForm
+
+
+admin.site.register(Tournament, TournamentAdmin)
+admin.site.register(Notification, NotificationAdmin)
 admin.site.register(ClassicWordle, ClassicWordleAdmin)
 admin.site.register(CustomUser, CustomUserAdmin)
 admin.site.register(Player, PlayerAdmin)

--- a/Wordle+/django/djapi/models.py
+++ b/Wordle+/django/djapi/models.py
@@ -48,11 +48,20 @@ class ClassicWordle(models.Model):
     date_played = models.DateTimeField(default=timezone.now)
     win = models.BooleanField(default=False)
 
-class Notifications(models.Model):
+# Model to store the notifications of the players.
+class Notification(models.Model):
     player = models.ForeignKey(Player, on_delete=models.CASCADE, related_name='notifications')
     text = models.CharField(max_length=200)
     link = models.URLField(blank=True)
     timestamp = models.DateTimeField(auto_now_add=True)
+
+# Model to store the tournaments information.
+class Tournament(models.Model):
+    name = models.CharField(max_length=20)
+    description = models.TextField(blank=True)
+    max_players = models.PositiveIntegerField()
+    word_length = models.PositiveIntegerField()
+    is_closed = models.BooleanField(default=False)
 
 # Method to add the 'Staff' group automatically when creating an administrator
 @receiver(post_save, sender=CustomUser)

--- a/Wordle+/django/djapi/serializers.py
+++ b/Wordle+/django/djapi/serializers.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import Group
-from .models import CustomUser, Player, StaffCode, ClassicWordle, Notifications
+from .models import CustomUser, Player, StaffCode, ClassicWordle, Notification, Tournament
 from rest_framework import serializers
 from django.contrib.auth.hashers import make_password
 
@@ -119,10 +119,15 @@ class ClassicWordleSerializer(serializers.ModelSerializer):
 
         return ClassicWordle.objects.create(**validated_data)
 
-class NotificationsSerializer(serializers.ModelSerializer):
+class NotificationSerializer(serializers.ModelSerializer):
     class Meta:
-        model = Notifications
+        model = Notification
         fields = ['text', 'link']
+
+class TournamentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Tournament
+        fields = ['name', 'description', 'max_players', 'word_length', 'is_closed']
 
 class GroupSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:


### PR DESCRIPTION
# Description

Closes: #34 
The aim of this PR is to add the tournament creation logic to the platform. A view to get the tournaments has been added, and the model is available on the Admin site for its management.