### PR TITLE
Added participation logic

### DIFF
--- a/Wordle+/django/djangoproject/urls.py
+++ b/Wordle+/django/djangoproject/urls.py
@@ -17,7 +17,7 @@ from django.urls import include, path
 from django.contrib import admin
 from rest_framework import routers
 from djapi import views
-from djapi.views import CustomObtainAuthToken, CheckTokenExpirationView, AvatarView, UserInfoAPIView, TournamentViewSet
+from djapi.views import CustomObtainAuthToken, CheckTokenExpirationView, AvatarView, UserInfoAPIView, TournamentViewSet, ParticipationViewSet
 from django.conf import settings
 from django.conf.urls.static import static
 
@@ -40,4 +40,6 @@ urlpatterns = [
     path('api/avatar/<int:user_id>/', AvatarView.as_view(), name='avatar'),
     path('api/users-info/', UserInfoAPIView.as_view(), name='user-detail'),
     path('api/tournaments/', TournamentViewSet.as_view({'get': 'list'}), name='tournaments-list'),
+    path('api/participations/', ParticipationViewSet.as_view({'get': 'list', 'post': 'create'}), name='participations'),
+    
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/Wordle+/django/djapi/models.py
+++ b/Wordle+/django/djapi/models.py
@@ -59,9 +59,29 @@ class Notification(models.Model):
 class Tournament(models.Model):
     name = models.CharField(max_length=20)
     description = models.TextField(blank=True)
+    num_players = models.PositiveIntegerField(default=0)
     max_players = models.PositiveIntegerField()
     word_length = models.PositiveIntegerField()
     is_closed = models.BooleanField(default=False)
+
+    def __str__(self):
+        return self.name
+    
+class Participation(models.Model):
+    tournament = models.ForeignKey(Tournament, on_delete=models.CASCADE)
+    player = models.ForeignKey(Player, on_delete=models.CASCADE)
+    timestamp = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=['tournament', 'player'],
+                name='unique_participation'
+            )
+        ]
+
+    def __str__(self):
+        return f"{self.player.user.username} - {self.tournament.name}"
 
 # Method to add the 'Staff' group automatically when creating an administrator
 @receiver(post_save, sender=CustomUser)

--- a/Wordle+/django/djapi/serializers.py
+++ b/Wordle+/django/djapi/serializers.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import Group
-from .models import CustomUser, Player, StaffCode, ClassicWordle, Notification, Tournament
+from .models import CustomUser, Player, StaffCode, ClassicWordle, Notification, Tournament, Participation
 from rest_framework import serializers
 from django.contrib.auth.hashers import make_password
 
@@ -127,7 +127,12 @@ class NotificationSerializer(serializers.ModelSerializer):
 class TournamentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tournament
-        fields = ['name', 'description', 'max_players', 'word_length', 'is_closed']
+        fields = ['id', 'name', 'description', 'max_players', 'num_players', 'word_length', 'is_closed']
+
+class ParticipationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Participation
+        fields = '__all__'
 
 class GroupSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:

--- a/Wordle+/django/djapi/views.py
+++ b/Wordle+/django/djapi/views.py
@@ -279,7 +279,7 @@ class ParticipationViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     def list(self, request):
-        tournament_id = int(request.query_params.get('tournament_id'),10)
+        tournament_id = request.query_params.get('tournament_id')
         if not tournament_id:
             return Response({'error': 'tournament_id parameter is required.'}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -320,6 +320,10 @@ class ParticipationViewSet(viewsets.ModelViewSet):
 
         participation = Participation.objects.create(tournament=tournament, player=player)
         tournament.num_players += 1
+        # Close the tournament if is full
+        if tournament.num_players >= tournament.max_players:
+            tournament.is_closed = True
+            
         tournament.save()
 
         # Create the related notification to the player

--- a/Wordle+/django/djapi/views.py
+++ b/Wordle+/django/djapi/views.py
@@ -272,4 +272,63 @@ class TournamentViewSet(viewsets.ReadOnlyModelViewSet):
             queryset = queryset.filter(word_length=word_length)
 
         return queryset
+
+class ParticipationViewSet(viewsets.ModelViewSet):
+    queryset = Participation.objects.all()
+    serializer_class = ParticipationSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def list(self, request):
+        tournament_id = int(request.query_params.get('tournament_id'),10)
+        if not tournament_id:
+            return Response({'error': 'tournament_id parameter is required.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        queryset = self.get_queryset().filter(tournament_id=tournament_id)
+        serializer = self.serializer_class(queryset, many=True)
+        return Response(serializer.data)
+    
+    def create(self, request, *args, **kwargs):
+        tournament_id = request.data.get('tournament_id')
+        player = request.user.player
+
+        # Request tournament_id field
+        if not tournament_id:
+            return Response({'error': 'tournament_id field is required.'}, status=404)
+        # Check if the user is a player
+        if not player:
+            return Response({'error': 'Player not found'}, status=404)
+
+        # Case of non existing tournament
+        try:
+            tournament = Tournament.objects.get(id=tournament_id)
+        except Tournament.DoesNotExist:
+            return Response({'error': 'Invalid tournament ID'}, status=400)
+        
+        # Case of existing participation
+        if Participation.objects.filter(tournament_id=tournament_id, player=player).exists():
+            return Response({'error': 'You are participating in this tournament.'}, status=status.HTTP_400_BAD_REQUEST)
+        
+        # Case of the tournament is closed
+        if tournament.is_closed:
+            return Response({'error': 'Tournament is closed for participation'}, status=400)
+
+        # Close the tournament if is full
+        if tournament.num_players >= tournament.max_players:
+            tournament.is_closed = True
+            tournament.save()
+            return Response({'error': 'Tournament is already full'}, status=400)
+
+        participation = Participation.objects.create(tournament=tournament, player=player)
+        tournament.num_players += 1
+        tournament.save()
+
+        # Create the related notification to the player
+        message = f"You were assigned in {tournament.name}. Good luck!"
+        link = "http://localhost:8100/tabs/tournaments"
+        notification = Notification.objects.create(player=player, text=message, link=link)
+        notification.save()
+
+        serializer = self.get_serializer(participation)
+        return Response(serializer.data, status=201)
+
     

--- a/Wordle+/ionic/ionic-app/src/app/tab2/tab2.page.html
+++ b/Wordle+/ionic/ionic-app/src/app/tab2/tab2.page.html
@@ -37,8 +37,8 @@
           <ion-label class="value">{{ tournament.description }}</ion-label>
         </ion-item>
         <ion-item>
-          <ion-label class="label">Max players:</ion-label>
-          <ion-label class="value">{{ tournament.max_players }}</ion-label>
+          <ion-label class="label">Players:</ion-label>
+          <ion-label class="value">{{ tournament.num_players }}/{{ tournament.max_players }}</ion-label>
         </ion-item>
         <ion-item>
           <ion-label class="label">Word Length:</ion-label>


### PR DESCRIPTION
# Description

Closes: #42 
The aim of this PR is to add all the logic related to the creation and management of the participations, either with the Admin site or the API endpoint. The tournament is successfully updated and the notification is created when a new participant is added to a tournament.